### PR TITLE
Fix links to spark api docs

### DIFF
--- a/src/main/scala/sparkworkshop/WordCount2.scala
+++ b/src/main/scala/sparkworkshop/WordCount2.scala
@@ -4,7 +4,7 @@ import com.typesafe.sparkworkshop.util.FileUtil
 import org.apache.spark.SparkContext
 // Implicit conversions, such as methods defined in
 // org.apache.spark.rdd.PairRDDFunctions
-// (http://spark.apache.org/docs/1.1.0/api/core/index.html#org.apache.spark.rdd.PairRDDFunctions)
+// (http://spark.apache.org/docs/1.1.0/api/scala/index.html#org.apache.spark.rdd.PairRDDFunctions)
 import org.apache.spark.SparkContext._
 
 /**
@@ -68,14 +68,14 @@ object WordCount2 {
     //   The data directory contains similar files for the Tanach (t3utf.dat - in Hebrew),
     //   the Latin Vulgate (vuldat.txt), the Septuagint (sept.txt - Greek)
     // Exercise: See the Scaladoc page for `OrderedRDDFunctions`:
-    //   http://spark.apache.org/docs/1.1.0/api/core/index.html#org.apache.spark.rdd.OrderedRDDFunctions
+    //   http://spark.apache.org/docs/1.1.0/api/scala/index.html#org.apache.spark.rdd.OrderedRDDFunctions
     //   Sort the output by word, try both ascending and descending.
     //   Note this can be expensive for large data sets!
     // Exercise: Take the output from the previous exercise and count the number
     //   of words that start with each letter of the alphabet and each digit.
     // Exercise (Hard): Sort the output by count. You can't use the same
     //   approach as in the previous exercise. Hint: See RDD.keyBy
-    //   (http://spark.apache.org/docs/1.1.0/api/core/index.html#org.apache.spark.rdd.RDD)
+    //   (http://spark.apache.org/docs/1.1.0/api/scala/index.html#org.apache.spark.rdd.RDD)
     //   What's the most frequent word that isn't a "stop word".
     // Exercise (Hard): Group the word-count pairs by count. In other words,
     //   All pairs where the count is 1 are together (i.e., just one occurrence

--- a/src/main/scala/sparkworkshop/solns/WordCount2GroupBy.scala
+++ b/src/main/scala/sparkworkshop/solns/WordCount2GroupBy.scala
@@ -1,7 +1,7 @@
 import com.typesafe.sparkworkshop.util.FileUtil
 import org.apache.spark.SparkContext
 // Implicit conversions, such as methods defined in
-// [org.apache.spark.rdd.PairRDDFunctions](http://spark.apache.org/docs/1.1.0/api/core/index.html#org.apache.spark.rdd.PairRDDFunctions)
+// [org.apache.spark.rdd.PairRDDFunctions](http://spark.apache.org/docs/1.1.0/api/scala/index.html#org.apache.spark.rdd.PairRDDFunctions)
 import org.apache.spark.SparkContext._
 
 /** First implementation of Word Count */
@@ -57,14 +57,14 @@ object WordCount2GroupBy {
     }
 
     // Exercise: See the Scaladoc page for `OrderedRDDFunctions`:
-    //   http://spark.apache.org/docs/1.1.0/api/core/index.html#org.apache.spark.rdd.OrderedRDDFunctions
+    //   http://spark.apache.org/docs/1.1.0/api/scala/index.html#org.apache.spark.rdd.OrderedRDDFunctions
     //   Sort the output by word, try both ascending and descending.
     //   Note this can be expensive!
     // Exercise: Take the output from the previous exercise and count the number
     //   of words that start with each letter of the alphabet and each digit.
     // Exercise (Hard): Sort the output by count. You can't use the same
     //   approach as in the previous exercise. Hint: See RDD.keyBy
-    //   (http://spark.apache.org/docs/1.1.0/api/core/index.html#org.apache.spark.rdd.RDD)
+    //   (http://spark.apache.org/docs/1.1.0/api/scala/index.html#org.apache.spark.rdd.RDD)
     //   What's the most frequent word that isn't a "stop word".
     // Exercise (Hard): Group the word-count pairs by count. In other words,
     //   All pairs where the count is 1 are together (i.e., just one occurrence

--- a/src/main/scala/sparkworkshop/solns/WordCount2SortByCount.scala
+++ b/src/main/scala/sparkworkshop/solns/WordCount2SortByCount.scala
@@ -1,7 +1,7 @@
 import com.typesafe.sparkworkshop.util.FileUtil
 import org.apache.spark.SparkContext
 // Implicit conversions, such as methods defined in
-// [org.apache.spark.rdd.PairRDDFunctions](http://spark.apache.org/docs/1.1.0/api/core/index.html#org.apache.spark.rdd.PairRDDFunctions)
+// [org.apache.spark.rdd.PairRDDFunctions](http://spark.apache.org/docs/1.1.0/api/scala/index.html#org.apache.spark.rdd.PairRDDFunctions)
 import org.apache.spark.SparkContext._
 
 /**
@@ -57,14 +57,14 @@ object WordCount2SortByCount {
     }
 
     // Exercise: See the Scaladoc page for `OrderedRDDFunctions`:
-    //   http://spark.apache.org/docs/1.1.0/api/core/index.html#org.apache.spark.rdd.OrderedRDDFunctions
+    //   http://spark.apache.org/docs/1.1.0/api/scala/index.html#org.apache.spark.rdd.OrderedRDDFunctions
     //   Sort the output by word, try both ascending and descending.
     //   Note this can be expensive!
     // Exercise: Take the output from the previous exercise and count the number
     //   of words that start with each letter of the alphabet and each digit.
     // Exercise (Hard): Sort the output by count. You can't use the same
     //   approach as in the previous exercise. Hint: See RDD.keyBy
-    //   (http://spark.apache.org/docs/1.1.0/api/core/index.html#org.apache.spark.rdd.RDD)
+    //   (http://spark.apache.org/docs/1.1.0/api/scala/index.html#org.apache.spark.rdd.RDD)
     //   What's the most frequent word that isn't a "stop word".
     // Exercise (Hard): Group the word-count pairs by count. In other words,
     //   All pairs where the count is 1 are together (i.e., just one occurrence

--- a/src/main/scala/sparkworkshop/solns/WordCount2SortByWord.scala
+++ b/src/main/scala/sparkworkshop/solns/WordCount2SortByWord.scala
@@ -1,7 +1,7 @@
 import com.typesafe.sparkworkshop.util.FileUtil
 import org.apache.spark.SparkContext
 // Implicit conversions, such as methods defined in
-// [org.apache.spark.rdd.PairRDDFunctions](http://spark.apache.org/docs/1.1.0/api/core/index.html#org.apache.spark.rdd.PairRDDFunctions)
+// [org.apache.spark.rdd.PairRDDFunctions](http://spark.apache.org/docs/1.1.0/api/scala/index.html#org.apache.spark.rdd.PairRDDFunctions)
 import org.apache.spark.SparkContext._
 
 /**
@@ -54,14 +54,14 @@ object WordCount2SortByWord {
     }
 
     // Exercise: See the Scaladoc page for `OrderedRDDFunctions`:
-    //   http://spark.apache.org/docs/1.1.0/api/core/index.html#org.apache.spark.rdd.OrderedRDDFunctions
+    //   http://spark.apache.org/docs/1.1.0/api/scala/index.html#org.apache.spark.rdd.OrderedRDDFunctions
     //   Sort the output by word, try both ascending and descending.
     //   Note this can be expensive!
     // Exercise: Take the output from the previous exercise and count the number
     //   of words that start with each letter of the alphabet and each digit.
     // Exercise (Hard): Sort the output by count. You can't use the same
     //   approach as in the previous exercise. Hint: See RDD.keyBy
-    //   (http://spark.apache.org/docs/1.1.0/api/core/index.html#org.apache.spark.rdd.RDD)
+    //   (http://spark.apache.org/docs/1.1.0/api/scala/index.html#org.apache.spark.rdd.RDD)
     //   What's the most frequent word that isn't a "stop word".
     // Exercise (Hard): Group the word-count pairs by count. In other words,
     //   All pairs where the count is 1 are together (i.e., just one occurrence


### PR DESCRIPTION
The links to the spark api docs have changed
