### PR TITLE
Added an option to work through the code using Jupyter notebooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ project/sbt-ui.sbt
 .ensime
 .ensime_cache
 notebooks/.ipynb_checkpoints/
+notebooks/output/
+notebooks/streaming-output/
+notebooks/tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ notebooks/.ipynb_checkpoints/
 notebooks/output/
 notebooks/streaming-output/
 notebooks/tmp/
+notebooks/spark-warehouse/

--- a/notebooks/10_SparkStreaming.ipynb
+++ b/notebooks/10_SparkStreaming.ipynb
@@ -29,7 +29,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -62,7 +62,7 @@
        "2"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -87,7 +87,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -119,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -128,7 +128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -137,7 +137,7 @@
        "true"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -155,7 +155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -174,7 +174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -245,14 +245,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "sc = org.apache.spark.SparkContext@5fdcecbe\n",
-       "ssc = org.apache.spark.streaming.StreamingContext@45d8ee39\n"
+       "sc = org.apache.spark.SparkContext@31da4833\n",
+       "ssc = org.apache.spark.streaming.StreamingContext@79b3680f\n"
       ]
      },
      "metadata": {},
@@ -261,10 +261,10 @@
     {
      "data": {
       "text/plain": [
-       "org.apache.spark.streaming.StreamingContext@45d8ee39"
+       "org.apache.spark.streaming.StreamingContext@79b3680f"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -289,7 +289,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -320,7 +320,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -338,16 +338,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "lines = org.apache.spark.streaming.dstream.MappedDStream@60b551bc\n",
-       "words = org.apache.spark.streaming.dstream.FlatMappedDStream@7e661ad\n",
-       "pairs = org.apache.spark.streaming.dstream.MappedDStream@629f6ead\n",
-       "wordCounts = org.apache.spark.streaming.dstream.ShuffledDStream@208ecd73\n"
+       "lines = org.apache.spark.streaming.dstream.MappedDStream@75d6a390\n",
+       "words = org.apache.spark.streaming.dstream.FlatMappedDStream@3879ca1b\n",
+       "pairs = org.apache.spark.streaming.dstream.MappedDStream@299e0184\n",
+       "wordCounts = org.apache.spark.streaming.dstream.ShuffledDStream@47565b39\n"
       ]
      },
      "metadata": {},
@@ -356,10 +356,10 @@
     {
      "data": {
       "text/plain": [
-       "org.apache.spark.streaming.dstream.ShuffledDStream@208ecd73"
+       "org.apache.spark.streaming.dstream.ShuffledDStream@47565b39"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -399,7 +399,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -415,7 +415,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -432,7 +432,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -446,7 +446,7 @@
     {
      "data": {
       "text/plain": [
-       "directoryServerThread = Thread[Thread-21,5,restricted-64d53ac1-e691-4d8f-ac23-19b9011ff9e8]\n"
+       "directoryServerThread = Thread[Thread-22,5,restricted-b87dcd55-e2f0-41e7-982e-fe2d581c6bcd]\n"
       ]
      },
      "metadata": {},
@@ -455,10 +455,10 @@
     {
      "data": {
       "text/plain": [
-       "Thread[Thread-21,5,restricted-64d53ac1-e691-4d8f-ac23-19b9011ff9e8]"
+       "Thread[Thread-22,5,restricted-b87dcd55-e2f0-41e7-982e-fe2d581c6bcd]"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -481,7 +481,111 @@
       "\n",
       "Iteration 8: destination: /home/jovyan/notebooks/tmp/streaming-input/0024.2003-12-21.GP.spam.txt\n",
       "\n",
-      "Iteration 9: destination: /home/jovyan/notebooks/tmp/streaming-input/0029.2004-08-03.BG.spam.txt\n"
+      "Iteration 9: destination: /home/jovyan/notebooks/tmp/streaming-input/0029.2004-08-03.BG.spam.txt\n",
+      "\n",
+      "Iteration 10: destination: /home/jovyan/notebooks/tmp/streaming-input/0003.2003-12-18.GP.spam.txt\n",
+      "\n",
+      "Iteration 11: destination: /home/jovyan/notebooks/tmp/streaming-input/0037.2001-08-05.SA_and_HP.spam.txt\n",
+      "\n",
+      "Iteration 12: destination: /home/jovyan/notebooks/tmp/streaming-input/0004.2004-08-01.BG.spam.txt\n",
+      "\n",
+      "Iteration 13: destination: /home/jovyan/notebooks/tmp/streaming-input/0019.2001-07-06.SA_and_HP.spam.txt\n",
+      "\n",
+      "Iteration 14: destination: /home/jovyan/notebooks/tmp/streaming-input/0038.2001-08-05.SA_and_HP.spam.txt\n",
+      "\n",
+      "Iteration 15: destination: /home/jovyan/notebooks/tmp/streaming-input/0029.2003-12-21.GP.spam.txt\n",
+      "\n",
+      "Iteration 16: destination: /home/jovyan/notebooks/tmp/streaming-input/0014.2003-12-19.GP.spam.txt\n",
+      "\n",
+      "Iteration 17: destination: /home/jovyan/notebooks/tmp/streaming-input/0023.2001-08-01.SA_and_HP.spam.txt\n",
+      "\n",
+      "Iteration 18: destination: /home/jovyan/notebooks/tmp/streaming-input/0007.2004-08-01.BG.spam.txt\n",
+      "\n",
+      "Iteration 19: destination: /home/jovyan/notebooks/tmp/streaming-input/0007.2003-12-18.GP.spam.txt\n",
+      "\n",
+      "Iteration 20: destination: /home/jovyan/notebooks/tmp/streaming-input/0032.2001-08-01.SA_and_HP.spam.txt\n",
+      "\n",
+      "Iteration 21: destination: /home/jovyan/notebooks/tmp/streaming-input/0008.2001-06-12.SA_and_HP.spam.txt\n",
+      "\n",
+      "Iteration 22: destination: /home/jovyan/notebooks/tmp/streaming-input/0016.2001-07-05.SA_and_HP.spam.txt\n",
+      "\n",
+      "Iteration 23: destination: /home/jovyan/notebooks/tmp/streaming-input/0026.2003-12-21.GP.spam.txt\n",
+      "\n",
+      "Iteration 24: destination: /home/jovyan/notebooks/tmp/streaming-input/0016.2003-12-19.GP.spam.txt\n",
+      "\n",
+      "Iteration 25: destination: /home/jovyan/notebooks/tmp/streaming-input/0036.2001-08-05.SA_and_HP.spam.txt\n",
+      "\n",
+      "Iteration 26: destination: /home/jovyan/notebooks/tmp/streaming-input/0006.2003-12-18.GP.spam.txt\n",
+      "\n",
+      "Iteration 27: destination: /home/jovyan/notebooks/tmp/streaming-input/0006.2004-08-01.BG.spam.txt\n",
+      "\n",
+      "Iteration 28: destination: /home/jovyan/notebooks/tmp/streaming-input/0025.2001-08-01.SA_and_HP.spam.txt\n",
+      "\n",
+      "Iteration 29: destination: /home/jovyan/notebooks/tmp/streaming-input/0005.2003-12-18.GP.spam.txt\n",
+      "\n",
+      "Iteration 30: destination: /home/jovyan/notebooks/tmp/streaming-input/0005.2001-06-23.SA_and_HP.spam.txt\n",
+      "\n",
+      "Iteration 31: destination: /home/jovyan/notebooks/tmp/streaming-input/0015.2003-12-19.GP.spam.txt\n",
+      "\n",
+      "Iteration 32: destination: /home/jovyan/notebooks/tmp/streaming-input/0013.2001-06-30.SA_and_HP.spam.txt\n",
+      "\n",
+      "Iteration 33: destination: /home/jovyan/notebooks/tmp/streaming-input/0028.2003-12-21.GP.spam.txt\n",
+      "\n",
+      "Iteration 34: destination: /home/jovyan/notebooks/tmp/streaming-input/0014.2001-07-04.SA_and_HP.spam.txt\n",
+      "\n",
+      "Iteration 35: destination: /home/jovyan/notebooks/tmp/streaming-input/0011.2001-06-29.SA_and_HP.spam.txt\n",
+      "\n",
+      "Iteration 36: destination: /home/jovyan/notebooks/tmp/streaming-input/0025.2003-12-21.GP.spam.txt\n",
+      "\n",
+      "Iteration 37: destination: /home/jovyan/notebooks/tmp/streaming-input/0002.2003-12-18.GP.spam.txt\n",
+      "\n",
+      "Iteration 38: destination: /home/jovyan/notebooks/tmp/streaming-input/0008.2003-12-18.GP.spam.txt\n",
+      "\n",
+      "Iteration 39: destination: /home/jovyan/notebooks/tmp/streaming-input/0012.2003-12-19.GP.spam.txt\n",
+      "\n",
+      "Iteration 40: destination: /home/jovyan/notebooks/tmp/streaming-input/0022.2004-08-03.BG.spam.txt\n",
+      "\n",
+      "Iteration 41: destination: /home/jovyan/notebooks/tmp/streaming-input/0029.2001-08-03.SA_and_HP.spam.txt\n",
+      "\n",
+      "Iteration 42: destination: /home/jovyan/notebooks/tmp/streaming-input/0008.2004-08-01.BG.spam.txt\n",
+      "\n",
+      "Iteration 43: destination: /home/jovyan/notebooks/tmp/streaming-input/0002.2004-08-01.BG.spam.txt\n",
+      "\n",
+      "Iteration 44: destination: /home/jovyan/notebooks/tmp/streaming-input/0022.2001-08-01.SA_and_HP.spam.txt\n",
+      "\n",
+      "Iteration 45: destination: /home/jovyan/notebooks/tmp/streaming-input/0030.2004-08-03.BG.spam.txt\n",
+      "\n",
+      "Iteration 46: destination: /home/jovyan/notebooks/tmp/streaming-input/0010.2003-12-18.GP.spam.txt\n",
+      "\n",
+      "Iteration 47: destination: /home/jovyan/notebooks/tmp/streaming-input/0020.2004-08-02.BG.spam.txt\n",
+      "\n",
+      "Iteration 48: destination: /home/jovyan/notebooks/tmp/streaming-input/0002.2001-05-25.SA_and_HP.spam.txt\n",
+      "\n",
+      "Iteration 49: destination: /home/jovyan/notebooks/tmp/streaming-input/0010.2004-08-01.BG.spam.txt\n",
+      "\n",
+      "Iteration 50: destination: /home/jovyan/notebooks/tmp/streaming-input/0030.2001-08-01.SA_and_HP.spam.txt\n",
+      "\n",
+      "Iteration 51: destination: /home/jovyan/notebooks/tmp/streaming-input/0020.2001-07-28.SA_and_HP.spam.txt\n",
+      "\n",
+      "Iteration 52: destination: /home/jovyan/notebooks/tmp/streaming-input/0030.2003-12-21.GP.spam.txt\n",
+      "\n",
+      "Iteration 53: destination: /home/jovyan/notebooks/tmp/streaming-input/0017.2003-12-18.GP.spam.txt\n",
+      "\n",
+      "Iteration 54: destination: /home/jovyan/notebooks/tmp/streaming-input/0027.2004-08-02.BG.spam.txt\n",
+      "\n",
+      "Iteration 55: destination: /home/jovyan/notebooks/tmp/streaming-input/0026.2003-12-18.GP.spam.txt\n",
+      "\n",
+      "Iteration 56: destination: /home/jovyan/notebooks/tmp/streaming-input/0011.2001-06-28.SA_and_HP.spam.txt\n",
+      "\n",
+      "Iteration 57: destination: /home/jovyan/notebooks/tmp/streaming-input/0017.2004-08-01.BG.spam.txt\n",
+      "\n",
+      "Iteration 58: destination: /home/jovyan/notebooks/tmp/streaming-input/0026.2001-07-13.SA_and_HP.spam.txt\n",
+      "\n",
+      "Iteration 59: destination: /home/jovyan/notebooks/tmp/streaming-input/0024.2004-08-02.BG.spam.txt\n",
+      "\n",
+      "Iteration 60: destination: /home/jovyan/notebooks/tmp/streaming-input/0032.2003-12-22.GP.spam.txt\n",
+      "\n",
+      "Iteration 61: destination: /home/jovyan/notebooks/tmp/streaming-input/0034.2004-08-03.BG.spam.txt\n"
      ]
     }
    ],
@@ -501,14 +605,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "streamRunnable = $anon$1@32713a46\n",
-       "streamThread = Thread[Thread-22,5,restricted-64d53ac1-e691-4d8f-ac23-19b9011ff9e8]\n"
+       "streamRunnable = $anon$1@17c9de6c\n",
+       "streamThread = Thread[Thread-23,5,restricted-b87dcd55-e2f0-41e7-982e-fe2d581c6bcd]\n"
       ]
      },
      "metadata": {},
@@ -517,10 +621,10 @@
     {
      "data": {
       "text/plain": [
-       "Thread[Thread-22,5,restricted-64d53ac1-e691-4d8f-ac23-19b9011ff9e8]"
+       "Thread[Thread-23,5,restricted-b87dcd55-e2f0-41e7-982e-fe2d581c6bcd]"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -529,33 +633,288 @@
      "output_type": "stream",
      "text": [
       "-------------------------------------------\n",
-      "Time: 1525611984000 ms\n",
+      "Time: 1527527578000 ms\n",
       "-------------------------------------------\n",
-      "(amnis,1)\n",
-      "(someone,4)\n",
-      "(country,1)\n",
-      "(call,3)\n",
-      "(offer,3)\n",
-      "(ll,5)\n",
-      "(agree,1)\n",
-      "(goals,1)\n",
+      "(amnis,2)\n",
+      "(crappie,1)\n",
+      "(someone,8)\n",
+      "(goals,2)\n",
+      "(ll,11)\n",
+      "(agree,2)\n",
+      "(xeni,2)\n",
+      "(forex,2)\n",
       "(greater,1)\n",
-      "(ore,1)\n",
+      "(order,8)\n",
       "...\n",
       "\n",
       "-------------------------------------------\n",
-      "Time: 1525611986000 ms\n",
+      "Time: 1527527580000 ms\n",
       "-------------------------------------------\n",
-      "(this,16)\n",
+      "(sent,1)\n",
+      "(blood,1)\n",
+      "(this,2)\n",
+      "(near,1)\n",
+      "(bone,1)\n",
+      "(healing,1)\n",
+      "(angrily,1)\n",
+      "(upon,1)\n",
+      "(dish,1)\n",
+      "(self,1)\n",
+      "...\n",
+      "\n",
+      "-------------------------------------------\n",
+      "Time: 1527527582000 ms\n",
+      "-------------------------------------------\n",
+      "(coverage,1)\n",
+      "(amnis,1)\n",
+      "(play,1)\n",
+      "(profit,1)\n",
+      "(stock,3)\n",
+      "(this,4)\n",
+      "(starting,1)\n",
+      "(is,2)\n",
+      "(its,1)\n",
+      "(otcbb,1)\n",
+      "...\n",
+      "\n",
+      "-------------------------------------------\n",
+      "Time: 1527527584000 ms\n",
+      "-------------------------------------------\n",
+      "(tantalum,1)\n",
+      "(under,2)\n",
+      "(health,1)\n",
+      "(its,10)\n",
+      "(arrange,2)\n",
+      "(ivernia,2)\n",
+      "(ore,1)\n",
+      "(forecasts,2)\n",
+      "(have,4)\n",
+      "(line,1)\n",
+      "...\n",
+      "\n",
+      "-------------------------------------------\n",
+      "Time: 1527527586000 ms\n",
+      "-------------------------------------------\n",
+      "(someone,3)\n",
+      "(ll,7)\n",
+      "(agree,1)\n",
+      "(offer,10)\n",
+      "(shot,1)\n",
+      "(pages,3)\n",
+      "(opening,1)\n",
+      "(ark,1)\n",
+      "(improve,1)\n",
+      "(counted,1)\n",
+      "...\n",
+      "\n",
+      "-------------------------------------------\n",
+      "Time: 1527527588000 ms\n",
+      "-------------------------------------------\n",
+      "(right,1)\n",
+      "(this,4)\n",
+      "(ll,1)\n",
+      "(fraud,1)\n",
+      "(offer,1)\n",
+      "(click,3)\n",
+      "(under,1)\n",
+      "(have,1)\n",
+      "(upon,1)\n",
+      "(plain,1)\n",
+      "...\n",
+      "\n",
+      "-------------------------------------------\n",
+      "Time: 1527527590000 ms\n",
+      "-------------------------------------------\n",
+      "(sponsoring,1)\n",
+      "(created,1)\n",
+      "(someone,3)\n",
+      "(ll,4)\n",
+      "(offer,3)\n",
+      "(pages,6)\n",
+      "(include,2)\n",
+      "(order,1)\n",
+      "(type,3)\n",
+      "(modification,1)\n",
+      "...\n",
+      "\n",
+      "-------------------------------------------\n",
+      "Time: 1527527592000 ms\n",
+      "-------------------------------------------\n",
+      "(under,2)\n",
+      "(this,4)\n",
+      "(starting,1)\n",
+      "(modem,1)\n",
+      "(its,2)\n",
+      "(click,2)\n",
+      "(combo,1)\n",
+      "(gigabyte,1)\n",
+      "(usb,1)\n",
+      "(self,1)\n",
+      "...\n",
+      "\n",
+      "-------------------------------------------\n",
+      "Time: 1527527594000 ms\n",
+      "-------------------------------------------\n",
+      "(lapel,1)\n",
+      "(vicodin,1)\n",
+      "(mayor,1)\n",
+      "(label,1)\n",
+      "(fp,1)\n",
+      "(pow,1)\n",
+      "(baritone,1)\n",
+      "(portrayal,1)\n",
+      "(day,1)\n",
+      "(matchbook,1)\n",
+      "...\n",
+      "\n",
+      "-------------------------------------------\n",
+      "Time: 1527527596000 ms\n",
+      "-------------------------------------------\n",
+      "(sweet,3)\n",
+      "(waggons,1)\n",
+      "(banner,2)\n",
+      "(someone,1)\n",
+      "(call,1)\n",
+      "(goals,2)\n",
+      "(ll,4)\n",
+      "(offer,1)\n",
+      "(bade,1)\n",
+      "(country,1)\n",
+      "...\n",
+      "\n",
+      "-------------------------------------------\n",
+      "Time: 1527527598000 ms\n",
+      "-------------------------------------------\n",
+      "(means,2)\n",
+      "(right,1)\n",
+      "(this,6)\n",
+      "(package,1)\n",
+      "(past,1)\n",
+      "(click,2)\n",
+      "(acceptable,1)\n",
+      "(writing,1)\n",
+      "(have,4)\n",
+      "(here,2)\n",
+      "...\n",
+      "\n",
+      "-------------------------------------------\n",
+      "Time: 1527527600000 ms\n",
+      "-------------------------------------------\n",
+      "(lis,1)\n",
+      "(free,1)\n",
+      "(are,1)\n",
+      "(have,1)\n",
+      "(fast,1)\n",
+      "(order,1)\n",
+      "(here,1)\n",
+      "(with,1)\n",
+      "(we,2)\n",
+      "(topics,1)\n",
+      "...\n",
+      "\n",
+      "-------------------------------------------\n",
+      "Time: 1527527602000 ms\n",
+      "-------------------------------------------\n",
+      "(receiving,1)\n",
+      "(call,1)\n",
+      "(this,3)\n",
+      "(abuse,1)\n",
+      "(myspyerase,1)\n",
+      "(is,3)\n",
+      "(swarming,1)\n",
+      "(previously,1)\n",
+      "(click,1)\n",
+      "(download,2)\n",
+      "...\n",
+      "\n",
+      "-------------------------------------------\n",
+      "Time: 1527527604000 ms\n",
+      "-------------------------------------------\n",
+      "(studio,1)\n",
+      "(right,1)\n",
+      "(country,1)\n",
+      "(this,1)\n",
+      "(youdo,1)\n",
+      "(click,2)\n",
+      "(finland,1)\n",
+      "(have,3)\n",
+      "(africa,1)\n",
+      "(licensing,1)\n",
+      "...\n",
+      "\n",
+      "-------------------------------------------\n",
+      "Time: 1527527606000 ms\n",
+      "-------------------------------------------\n",
+      "(banner,2)\n",
+      "(created,1)\n",
+      "(paper,1)\n",
+      "(ll,3)\n",
+      "(health,2)\n",
+      "(offer,1)\n",
+      "(its,1)\n",
+      "(reading,1)\n",
+      "(blocks,1)\n",
+      "(bright,1)\n",
+      "...\n",
+      "\n",
+      "-------------------------------------------\n",
+      "Time: 1527527608000 ms\n",
+      "-------------------------------------------\n",
+      "(solving,1)\n",
+      "(package,1)\n",
+      "(dispatch,1)\n",
+      "(anxiety,1)\n",
+      "(zoloft,1)\n",
+      "(health,1)\n",
+      "(loo,1)\n",
+      "(pain,1)\n",
+      "(tablet,1)\n",
+      "(xenical,1)\n",
+      "...\n",
+      "\n",
+      "-------------------------------------------\n",
+      "Time: 1527527610000 ms\n",
+      "-------------------------------------------\n",
+      "(under,1)\n",
+      "(country,4)\n",
+      "(offer,1)\n",
+      "(proceed,1)\n",
+      "(event,1)\n",
+      "(materially,1)\n",
+      "(have,2)\n",
+      "(added,1)\n",
+      "(simulator,1)\n",
+      "(chrome,1)\n",
+      "...\n",
+      "\n",
+      "-------------------------------------------\n",
+      "Time: 1527527612000 ms\n",
+      "-------------------------------------------\n",
+      "(spigot,1)\n",
+      "(doctoral,1)\n",
+      "(this,14)\n",
       "(country,6)\n",
       "(offer,1)\n",
+      "(aphrodite,1)\n",
+      "(brim,1)\n",
       "(arrested,1)\n",
-      "(click,2)\n",
       "(general,1)\n",
       "(transferred,1)\n",
-      "(have,6)\n",
-      "(here,2)\n",
-      "(only,1)\n",
+      "...\n",
+      "\n",
+      "-------------------------------------------\n",
+      "Time: 1527527614000 ms\n",
+      "-------------------------------------------\n",
+      "(qnijnh,1)\n",
+      "(zeal,1)\n",
+      "(right,1)\n",
+      "(offer,1)\n",
+      "(is,1)\n",
+      "(ocd,1)\n",
+      "(currently,1)\n",
+      "(click,1)\n",
+      "(contravention,1)\n",
+      "(have,2)\n",
       "...\n",
       "\n"
      ]
@@ -581,7 +940,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -609,7 +968,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -625,7 +984,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
There are now three options: 1) Jupyter notebooks, 2) compiles apps, 3) scripts (using the equivalent of `spark-shell`).

Using Jupyter notebooks is easiest, but this approach can't cover as many options as the other two examples, especially if you find it necessary to work with Spark apps or scripts. Then it's worth going through the second and/or third option after learning the APIs using the Jupyter notebooks.