### PR TITLE
Fixing the order of the NxM code in Matrix4

### DIFF
--- a/src/main/scala/sparktutorial/Matrix4.scala
+++ b/src/main/scala/sparktutorial/Matrix4.scala
@@ -57,14 +57,14 @@ object Matrix4 {
 
     try {
       // Set up a mxn matrix of numbers.
-      val matrix = Matrix(dimensions.m, dimensions.n)
+      val matrix = Matrix(dimensions.n, dimensions.m)
 
       // Average rows of the matrix in parallel:
-      val sums_avgs = sc.parallelize(1 to dimensions.m).map { i =>
+      val sums_avgs = sc.parallelize(1 to dimensions.n).map { i =>
         // Matrix indices count from 0.
         // "_ + _" is the same as "(count1, count2) => count1 + count2".
         val sum = matrix(i-1) reduce (_ + _)
-        (sum, sum/dimensions.n)
+        (sum, sum/dimensions.m)
       }.collect    // convert to an array
 
       // Make a new sequence of strings with the formatted output, then we'll
@@ -72,7 +72,7 @@ object Matrix4 {
       // (Use fully-qualified path to Vector to avoid confusion with Spark's
       // Vector class in MLlib.)
       val outputLines = scala.collection.immutable.Vector(
-        s"${dimensions.m}x${dimensions.n} Matrix:") ++
+        s"${dimensions.n}x${dimensions.m} Matrix:") ++
         sums_avgs.zipWithIndex.map {
           case ((sum, avg), index) =>
             f"Row #${index}%2d: Sum = ${sum}%4d, Avg = ${avg}%3d"

--- a/src/main/scala/sparktutorial/Matrix4.scala
+++ b/src/main/scala/sparktutorial/Matrix4.scala
@@ -10,7 +10,7 @@ import org.apache.spark.SparkContext
  */
 object Matrix4 {
 
-  case class Dimensions(m: Int, n: Int)
+  case class Dimensions(n: Int, m: Int)
 
   def main(args: Array[String]): Unit = {
 
@@ -41,7 +41,7 @@ object Matrix4 {
 
     val dimsRE = """(\d+)\s*x\s*(\d+)""".r
     val dimensions = argz("dims") match {
-      case dimsRE(m, n) => Dimensions(m.toInt, n.toInt)
+      case dimsRE(n, m) => Dimensions(n.toInt, m.toInt)
       case s =>
         println(s"""Expected matrix dimensions 'NxM', but got this: $s""")
         sys.exit(1)


### PR DESCRIPTION
I was going through `Matrix4` in the tutorial earlier today and was confused as to why this piece of code was creating a `Seq` from `1 to m` instead of `1 to n`

`sc.parallelize(1 to dimensions.m)`

I launched the code in a debugger and it turns out that the problem was with the handling of the  regex being converted into the `Dimensions` case class. The line `case dimsRE(m, n) => Dimensions(m.toInt, n.toInt)` switches the order of the dimensions and then passes them to `Dimensions`. The code still works as intended because the rest of it refers to `m` as the number of rows and `n` as the number of columns

The below screenshot was taken while debugging `Matrix4` using the default arguments
![ss 2018-08-22 at 21 03 09 png](https://user-images.githubusercontent.com/1320012/44500587-e685fa00-a64e-11e8-80bb-d1e724b5ec0f.png)

In my fix, I swapped the ordering of `m` and `n` to reflect the original intent and edited a few bits of code so that the output would still be as intended