### PR TITLE
typo mistake

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name          := "spark-scala-tutorial"
 organization  := "com.lightbend"
-description   := "Spark Spark Tutorial"
+description   := "Spark Scala Tutorial"
 version       := "6.0.0"
 scalaVersion  := "2.11.8"
 scalacOptions := Seq("-deprecation", "-unchecked", "-encoding", "utf8", "-Xlint")


### PR DESCRIPTION
This should be "Spark Scala tutorial" (not "Spark Spark tutorial"), right?